### PR TITLE
Add restaurants created column to admin users

### DIFF
--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -9,10 +9,15 @@ import { toast } from "react-hot-toast";
 import { upperFirst } from "lodash";
 import { ToggleSwitch } from "components/controls/ToggleSwitch";
 import { withI18n } from "../../lib/withI18n";
+import Modal from "react-responsive-modal";
+import { X } from "react-feather";
 
 const Users = () => {
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [restaurants, setRestaurants] = useState([]);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalUser, setModalUser] = useState("");
   const { currentUser, loading: currentUserLoading } = useCurrentUser();
   const { push } = useRouter();
 
@@ -38,6 +43,17 @@ const Users = () => {
       .post(`/api/users/${id}/make-admin`, { isAdmin })
       .then(() => {
         toast.success(isAdmin ? "Made admin!" : "Unmade admin!");
+      })
+      .catch((e) => toast.error(e.message));
+  };
+
+  const handleOpenRestaurants = async (id, name) => {
+    await axios
+      .get(`/api/users/${id}/restaurants`)
+      .then(({ data }) => {
+        setRestaurants(data);
+        setModalUser(name);
+        setModalOpen(true);
       })
       .catch((e) => toast.error(e.message));
   };
@@ -83,6 +99,9 @@ const Users = () => {
             <th className="bg-slate-100 border-b font-medium p-4 pl-8 pb-3 text-slate-500 text-left">
               Watched
             </th>
+            <th className="bg-slate-100 border-b font-medium p-4 pl-8 pb-3 text-slate-500 text-left">
+              Restaurants Created
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -125,10 +144,35 @@ const Users = () => {
               <td className="border-b border-slate-100 p-2 pl-8 text-slate-500">
                 {user.watchlistCount}
               </td>
+              <td className="border-b border-slate-100 p-2 pl-8 text-slate-500">
+                <button
+                  className="underline text-blue-600"
+                  onClick={() => handleOpenRestaurants(user._id, user.name)}
+                >
+                  {user.restaurantsCreatedCount}
+                </button>
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
+      <Modal
+        classNames={{ overlay: "customOverlay", modal: "customModal" }}
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        closeIcon={<X />}
+        center
+      >
+        <h2 className="text-lg font-bold mb-4">Restaurants created by {modalUser}</h2>
+        <ul className="space-y-1">
+          {restaurants.map((r) => (
+            <li key={r._id} className="flex justify-between">
+              <span>{r.name}</span>
+              <span>{r.approved ? "✅" : "❌"}</span>
+            </li>
+          ))}
+        </ul>
+      </Modal>
     </div>
   );
 };

--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -145,12 +145,18 @@ const Users = () => {
                 {user.watchlistCount}
               </td>
               <td className="border-b border-slate-100 p-2 pl-8 text-slate-500">
-                <button
-                  className="underline text-blue-600"
-                  onClick={() => handleOpenRestaurants(user._id, user.name)}
-                >
-                  {user.restaurantsCreatedCount}
-                </button>
+                {user.restaurantsCreatedCount > 0 ? (
+                  <button
+                    className="underline text-blue-600"
+                    onClick={() =>
+                      handleOpenRestaurants(user._id, user.name)
+                    }
+                  >
+                    {user.restaurantsCreatedCount}
+                  </button>
+                ) : (
+                  <span>{user.restaurantsCreatedCount}</span>
+                )}
               </td>
             </tr>
           ))}
@@ -167,7 +173,14 @@ const Users = () => {
         <ul className="space-y-1">
           {restaurants.map((r) => (
             <li key={r._id} className="flex justify-between">
-              <span>{r.name}</span>
+              <a
+                href={`/restaurants/${r.slug}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline text-blue-600"
+              >
+                {r.name}
+              </a>
               <span>{r.approved ? "✅" : "❌"}</span>
             </li>
           ))}

--- a/pages/api/users/[id]/restaurants.js
+++ b/pages/api/users/[id]/restaurants.js
@@ -1,0 +1,21 @@
+import { ObjectId } from "mongodb";
+import nextConnect from "next-connect";
+import { database } from "middleware/database";
+import { isAdmin } from "../../../../lib/middleware/isAdmin";
+
+const handler = nextConnect();
+handler.use(database);
+
+handler.get(async (req, res) => {
+  const db = req.db;
+  const restaurants = await db
+    .collection("restaurants")
+    .find({ creatorId: new ObjectId(req.query.id) })
+    .project({ name: 1, slug: 1, approved: 1 })
+    .sort({ createdAt: -1 })
+    .toArray();
+
+  res.status(200).json(restaurants);
+});
+
+export default isAdmin(handler);

--- a/pages/api/users/index.js
+++ b/pages/api/users/index.js
@@ -27,17 +27,27 @@ handler.get(async (req, res) => {
         },
       },
       {
+        $lookup: {
+          from: "restaurants",
+          localField: "_id",
+          foreignField: "creatorId",
+          as: "createdRestaurants",
+        },
+      },
+      {
         $addFields: {
           eatenlistCount: { $size: "$eatenlist" },
           watchlistCount: { $size: "$watchlist" },
           reviewCount: { $size: "$userReviews" },
           connectedAccount: { $arrayElemAt: ["$connectedAccounts", 0] },
+          restaurantsCreatedCount: { $size: "$createdRestaurants" },
         },
       },
       {
         $project: {
           userReviews: 0,
           connectedAccounts: 0,
+          createdRestaurants: 0,
           "connectedAccount.refreshToken": 0,
           "connectedAccount.accessToken": 0,
           "connectedAccount.accessTokenExpires": 0,


### PR DESCRIPTION
## Summary
- expose restaurant creation count from the users API
- return restaurants created for a given user
- display a new *Restaurants Created* column in the admin users table
- show modal with a list of restaurants when clicking the number

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e92a57b88329ab72b7b405f3a28a