### PR TITLE
Add Ranking pages with SEO content

### DIFF
--- a/components/layout/Sidebar.js
+++ b/components/layout/Sidebar.js
@@ -9,6 +9,7 @@ import {
   Star,
   CheckCircle,
   Edit3,
+  Award,
 } from "react-feather";
 import { useRouter } from "next/router";
 import classNames from "classnames";
@@ -135,6 +136,12 @@ export const Sidebar = ({ showMobileSidebar, toggleMobileSidebar }) => {
               label={t("sidebar.restaurants")}
               icon={Map}
               href="/restaurants"
+            />
+            <Item
+              onClick={onClickItem}
+              label={t("sidebar.ranking")}
+              icon={Award}
+              href="/classement"
             />
             <Item
               onClick={onClickItem}

--- a/pages/classement/index.js
+++ b/pages/classement/index.js
@@ -1,0 +1,24 @@
+import Head from "next/head";
+import { useTranslation } from "next-i18next";
+import { withI18n } from "../../lib/withI18n";
+
+const Ranking = () => {
+  const { t } = useTranslation();
+  return (
+    <>
+      <Head>
+        <title>{t("ranking.pageTitle")}</title>
+        <meta name="description" content={t("ranking.metaDescription")} />
+      </Head>
+      <div className="p-5 mx-auto max-w-3xl">
+        <h1 className="text-2xl font-black mb-5 text-center">
+          {t("ranking.title")}
+        </h1>
+      </div>
+    </>
+  );
+};
+
+export const getStaticProps = withI18n();
+
+export default Ranking;

--- a/pages/classement/montreal.js
+++ b/pages/classement/montreal.js
@@ -1,0 +1,28 @@
+import Head from "next/head";
+import { useTranslation } from "next-i18next";
+import { withI18n } from "../../lib/withI18n";
+
+const keywords = "avis poutine, chez poutine, critique poutine, la meilleur poutine de montreal, la meilleure poutine à montréal, la meilleure poutine de montreal, le s poutine, les meilleurs poutines de montreal, livraison poutine montreal, livraison poutine montréal, manger poutine montreal, manger une poutine a montreal, meilleur poutine de montreal, meilleur poutine montréal, meilleur restaurant de poutine a montreal, meilleure poutine à montréal, meilleure poutine de montreal, meilleure poutine de montréal, meilleure poutine livraison montréal, meilleure poutine montréal 2021, montréal poutine, montreal restaurant poutine, poutine à montréal, poutine de montreal, poutine en montreal, poutine livraison montreal, poutine livraison montréal, poutine montréal, poutine montreal livraison, poutine mtl, restaurant a poutine, restaurant de poutine, restaurant de poutine montreal, restaurant poutine a montreal, restaurant poutine montréal, resto de poutine, resto la poutine, resto poutine montreal";
+
+const MontrealRanking = () => {
+  const { t } = useTranslation();
+  return (
+    <>
+      <Head>
+        <title>{t("ranking.montreal.pageTitle")}</title>
+        <meta name="description" content={t("ranking.montreal.metaDescription")} />
+        <meta name="keywords" content={keywords} />
+      </Head>
+      <div className="p-5 mx-auto max-w-3xl">
+        <h1 className="text-2xl font-black mb-5 text-center">
+          {t("ranking.montreal.heading")}
+        </h1>
+        <p className="mb-4">{t("ranking.montreal.intro")}</p>
+      </div>
+    </>
+  );
+};
+
+export const getStaticProps = withI18n();
+
+export default MontrealRanking;

--- a/pages/classement/quebec-city.js
+++ b/pages/classement/quebec-city.js
@@ -1,0 +1,24 @@
+import Head from "next/head";
+import { useTranslation } from "next-i18next";
+import { withI18n } from "../../lib/withI18n";
+
+const QuebecCityRanking = () => {
+  const { t } = useTranslation();
+  return (
+    <>
+      <Head>
+        <title>{t("ranking.quebecCity.pageTitle")}</title>
+        <meta name="description" content={t("ranking.quebecCity.metaDescription")} />
+      </Head>
+      <div className="p-5 mx-auto max-w-3xl">
+        <h1 className="text-2xl font-black mb-5 text-center">
+          {t("ranking.quebecCity.heading")}
+        </h1>
+      </div>
+    </>
+  );
+};
+
+export const getStaticProps = withI18n();
+
+export default QuebecCityRanking;

--- a/pages/ranking/index.js
+++ b/pages/ranking/index.js
@@ -1,0 +1,1 @@
+export { default, getStaticProps } from "../classement";

--- a/pages/ranking/montreal.js
+++ b/pages/ranking/montreal.js
@@ -1,0 +1,1 @@
+export { default, getStaticProps } from "../classement/montreal";

--- a/pages/ranking/quebec-city.js
+++ b/pages/ranking/quebec-city.js
@@ -1,0 +1,1 @@
+export { default, getStaticProps } from "../classement/quebec-city";

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -374,6 +374,7 @@
     "profile": "My profile",
     "rate": "Rate a poutine",
     "restaurants": "Poutine map",
+    "ranking": "Ranking",
     "toTry": "To try"
   },
   "signup": {
@@ -482,6 +483,22 @@
       "error": "An error occurred: ",
       "loading": "Sending...",
       "success": "Email sent!"
+    }
+  },
+  "ranking": {
+    "title": "Ranking",
+    "pageTitle": "Best Poutine Rankings | Poutine Mania",
+    "metaDescription": "Browse the community ranking of the best poutines in Quebec and Canada.",
+    "montreal": {
+      "heading": "Best poutine in Montreal",
+      "pageTitle": "Best poutine in Montreal | Poutine Mania",
+      "metaDescription": "See our ranking of the best poutine in Montreal.",
+      "intro": "Check our reviews to find where to eat the best poutine in Montreal."
+    },
+    "quebecCity": {
+      "heading": "Best poutine in Quebec City",
+      "pageTitle": "Best poutine in Quebec City | Poutine Mania",
+      "metaDescription": "Discover the top poutine spots in Quebec City."
     }
   },
   "watchlist": {

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -374,6 +374,7 @@
     "profile": "Mon profil",
     "rate": "Noter une poutine",
     "restaurants": "Carte des poutines",
+    "ranking": "Classement",
     "toTry": "À essayer"
   },
   "signup": {
@@ -483,6 +484,22 @@
       "error": "Une erreur est survenue: ",
       "loading": "Envoi...",
       "success": "Courriel envoyé!"
+    }
+  },
+  "ranking": {
+    "title": "Classement",
+    "pageTitle": "Classement des meilleures poutines | Poutine Mania",
+    "metaDescription": "Découvrez le classement des meilleures poutines au Québec et au Canada.",
+    "montreal": {
+      "heading": "Meilleure poutine à Montréal",
+      "pageTitle": "Meilleure poutine à Montréal | Poutine Mania",
+      "metaDescription": "Classement des meilleures poutines à Montréal selon la communauté.",
+      "intro": "Découvrez nos avis poutine et critiques poutine pour trouver la meilleure poutine de Montréal. Livraison poutine Montréal ou dégustation sur place, voici les restaurants de poutine incontournables."
+    },
+    "quebecCity": {
+      "heading": "Meilleure poutine à Québec",
+      "pageTitle": "Meilleure poutine à Québec | Poutine Mania",
+      "metaDescription": "Où manger la meilleure poutine à Québec? Consultez notre classement."
     }
   },
   "watchlist": {


### PR DESCRIPTION
## Summary
- add Classement/Ranking pages with city subpages
- translate ranking pages in French and English
- add Ranking link in sidebar navigation

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f5763c048329b1da6faca9079f8d